### PR TITLE
fix bug where array is detected as number

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -2,7 +2,7 @@ const constants = require('./constants');
 const util = require('./util');
 
 function isNumber(value){
-    return !isNaN(parseFloat(value)) && isFinite(value);
+    return typeof value === 'number' && !isNaN(value) && isFinite(value);
 }
 
 function appendValue(val, buffer) {
@@ -61,8 +61,10 @@ function appendValue(val, buffer) {
                 constant = constants.types.string;
             } else if (propValue === true || propValue === false || isNumber(propValue) || propValue instanceof Date) {
                 constant = constants.types.int;
-            } else {
+            } else if (typeof val === 'object') {
                 constant = constants.types.object;
+            } else {
+                throw new Error(`Writer encountered unhandled value: ${val}`);
             }
 
             let lengthInBytes = Buffer.byteLength(key);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-shortcut-editor",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Edit Steam shortcuts",
   "main": "index.js",
   "repository": {

--- a/test/write-read-tests.js
+++ b/test/write-read-tests.js
@@ -35,7 +35,10 @@ describe('write-read tests', function(){
             someDate: new Date(2001, 11, 15),
             numBER: 12345,
             NUMber: 92928,
-            flag: false
+            flag: false,
+            tags: [
+                7800
+            ]
         };
 
         let buffer = shortcut.writeBuffer(input);


### PR DESCRIPTION
Fixed number check. Previously it would detect `[7800]` as a number. Modified 1 test to check for this. 

I also added a stricter constant check, just in case something else could go wrong. 